### PR TITLE
easier output format

### DIFF
--- a/mav_sysid/mav_sysid.m
+++ b/mav_sysid/mav_sysid.m
@@ -7,6 +7,13 @@ control_topic = 'CONTROL TOPIC HERE EXAMPLE/mavros/setpoint_raw/roll_pitch_yawra
 sys_id_start_time_s = 10;
 sys_id_end_time_s = 150;
 
+% parameters that must be provided 
+system_mass_kg = 2.5;
+linear_drag_coefficients = [0.02, 0.02, 0]; %default values work for most systems
+yaw_gain = 1.0; %default value works for most systems
+yaw_damping = 0.95; %default value works for most systems
+yaw_omega = 5.0; %default value works for most systems
+
 %% read bag file
 path(path, '../read_bags');
 path(path, '../helper_functions');
@@ -17,8 +24,8 @@ clc;
 bag = ros.Bag(bag_name);
 bag.info
 
-imu_data = readImu(bag, '/nduk/mavros/imu/data');
-attitude_cmd = readCommandRollPitchYawRateThrust(bag, '/nduk/mavros/setpoint_raw/roll_pitch_yawrate_thrust');
+imu_data = readImu(bag, imu_topic);
+attitude_cmd = readCommandRollPitchYawRateThrust(bag, control_topic);
 %%
 
 imu_data.rpy = quat2rpy([imu_data.q(4,:)', imu_data.q(1:3,:)']');
@@ -54,7 +61,7 @@ ax.FontSize = 16;
 
 figure(3);
 ax = axes;
-plot(imu_data.t, imu_data.a(3, :), 'linewidth', 2);
+plot(imu_data.t, vecnorm(imu_data.a), 'linewidth', 2);
 hold on;
 plot(attitude_cmd.t, attitude_cmd.thrust, '--', 'linewidth', 2);
 xlabel('time');
@@ -71,13 +78,18 @@ attitude_cmd.rpy_interp(1,:) = interp1(attitude_cmd.t, attitude_cmd.rpy(1,:), im
 attitude_cmd.rpy_interp(2,:) = interp1(attitude_cmd.t, attitude_cmd.rpy(2,:), imu_data.t);
 attitude_cmd.rpy_interp(3,:) = interp1(attitude_cmd.t, attitude_cmd.rpy(3,:), imu_data.t);
 
+attitude_cmd.thrust_interp = zeros(size(imu_data.rpy));
+attitude_cmd.thrust_interp = interp1(attitude_cmd.t, attitude_cmd.thrust(3,:), imu_data.t);
+
 attitude_cmd.t = imu_data.t;
 
 imu_data.t = imu_data.t(imu_data.t > sys_id_start_time_s & imu_data.t < sys_id_end_time_s);
 imu_data.rpy = imu_data.rpy(:, imu_data.t > sys_id_start_time_s & imu_data.t < sys_id_end_time_s);
+imu_data.a = imu_data.a(:, imu_data.t > sys_id_start_time_s & imu_data.t < sys_id_end_time_s);
 
 attitude_cmd.t = attitude_cmd.t(attitude_cmd.t > sys_id_start_time_s & attitude_cmd.t < sys_id_end_time_s);
 attitude_cmd.rpy_interp = attitude_cmd.rpy_interp(:, attitude_cmd.t > sys_id_start_time_s & attitude_cmd.t < sys_id_end_time_s);
+attitude_cmd.thrust_interp = attitude_cmd.thrust_interp(:, attitude_cmd.t > sys_id_start_time_s & attitude_cmd.t < sys_id_end_time_s);
 
 dt = mean(diff(imu_data.t));
 roll_data = iddata(imu_data.rpy(1,:)', attitude_cmd.rpy_interp(1,:)', dt);
@@ -85,40 +97,66 @@ pitch_data = iddata(imu_data.rpy(2,:)', attitude_cmd.rpy_interp(2,:)', dt);
 
 roll_tf = tfest( roll_data, 1, 0);
 pitch_tf = tfest( pitch_data, 1, 0);
-disp('======================');
-disp('roll 1st order dynamics'); 
-% roll_tf
-fprintf('roll_gain: %f\n\n', dcgain(roll_tf));
-fprintf('roll_time_constant: %f\n\n', -1/pole(roll_tf));
-fprintf('fit percentage: %f %%\n', roll_tf.Report.Fit.FitPercent);
-disp('----------------------');
-disp('pitch 1st order dynamics'); 
-% pitch_tf
-fprintf('pitch_gain: %f\n\n', dcgain(pitch_tf));
-fprintf('pitch_time_constant: %f\n\n', -1/pole(pitch_tf));
-fprintf('fit percentage: %f\n', pitch_tf.Report.Fit.FitPercent);
+
+disp('=====================================================================');
+disp('1st order dynamics'); 
+fprintf('pitch fit percentage: %f%%\n', pitch_tf.Report.Fit.FitPercent);
+fprintf('roll fit percentage: %f%%\n\n', roll_tf.Report.Fit.FitPercent);
+disp('---------------------------------------------------------------------');
+disp('Copy the following into your nonlinear_mpc.yaml file')
+disp('---------------------------------------------------------------------');
+disp('# Controller Parameters:');
+fprintf('mass: %f\n',system_mass_kg);
+fprintf('roll_time_constant: %f\n', -1/pole(roll_tf));
+fprintf('roll_gain: %f\n', dcgain(roll_tf));
+fprintf('pitch_time_constant: %f\n', -1/pole(pitch_tf));
+fprintf('pitch_gain: %f\n', dcgain(pitch_tf));
+fprintf('linear_drag_coefficients: [%f, %f, %f]\n', linear_drag_coefficients(1),linear_drag_coefficients(2),linear_drag_coefficients(3));
+fprintf('yaw_gain: %f\n', yaw_gain);
+disp('---------------------------------------------------------------------');
 
 %2nd order
 roll_tf = tfest( roll_data, 2, 0);
 pitch_tf = tfest( pitch_data, 2, 0);
-disp('----------------------');
-disp('roll 2st order dynamics:'); 
-% roll_tf
-[Wn, damping] = damp(roll_tf);
-fprintf('roll_gain: %f\n\n', dcgain(roll_tf));
-fprintf('roll_damping_coef: %f\n\n', damping(1));
-fprintf('roll_natural_freq: %f\n\n', Wn(1));
-fprintf('fit percentage: %f\n', roll_tf.Report.Fit.FitPercent);
 
-disp('----------------------');
-disp('pitch 2st order dynamics:'); 
-% pitch_tf
-[Wn, damping] = damp(pitch_tf);
-fprintf('pitch_gain: %f\n\n', dcgain(pitch_tf));
-fprintf('pitch_damping_coef: %f\n\n', damping(1));
-fprintf('pitch_natural_freq: %f\n\n', Wn(1));
-fprintf('fit percentage: %f\n', pitch_tf.Report.Fit.FitPercent);
+[roll_Wn, roll_damping] = damp(roll_tf);
+[pitch_Wn, pitch_damping] = damp(pitch_tf);
 
+disp('=====================================================================');
+disp('2nd order dynamics'); 
+fprintf('pitch fit percentage: %f%%\n', pitch_tf.Report.Fit.FitPercent);
+fprintf('roll fit percentage: %f%%\n\n', roll_tf.Report.Fit.FitPercent);
+disp('---------------------------------------------------------------------');
+disp('Copy the following into your disturbance_observer.yaml file');
+disp('---------------------------------------------------------------------');
+disp('  #model from system identification (2nd order attitude model)');
+fprintf('  drag_coefficients: [%f, %f, %f]\n', linear_drag_coefficients(1),linear_drag_coefficients(2),linear_drag_coefficients(3));
+fprintf('  roll_gain: %f\n', dcgain(roll_tf));
+fprintf('  roll_damping: %f\n', roll_damping(1));
+fprintf('  roll_omega: %f\n', roll_Wn(1));
+fprintf('  pitch_gain: %f\n', dcgain(pitch_tf));
+fprintf('  pitch_damping: %f\n', pitch_damping(1));
+fprintf('  pitch_omega: %f\n', pitch_Wn(1));
+fprintf('  yaw_gain: %f\n', yaw_gain);
+fprintf('  yaw_damping: %f\n', yaw_damping);
+fprintf('  yaw_omega: %f\n', yaw_omega);
+disp('---------------------------------------------------------------------');
+
+%thrust
+acc_thrust_ratio = (vecnorm(imu_data.a)-9.81) ./ attitude_cmd.thrust_interp;
+acc_thrust_ratio = median(acc_thrust_ratio(acc_thrust_ratio > 0.0)) / system_mass_kg;
+
+disp('=====================================================================');
+disp('pixhawk thrust settings'); 
+disp('---------------------------------------------------------------------');
+disp('Copy the following into your px4_config.yaml file')
+disp('---------------------------------------------------------------------');
+disp('# setpoint_raw');
+disp('setpoint_raw:');
+fprintf('  thrust_scaling_factor: %f\n',acc_thrust_ratio);
+fprintf('  system_mass_kg: %f\n', system_mass_kg);
+fprintf('  yaw_rate_scaling_factor: %f\n', yaw_gain);
+disp('---------------------------------------------------------------------');
 
 
 %% 


### PR DESCRIPTION
Two changes:
- Add in thrust scaling estimation for the px4. 
- Format the output so it exactly matches what is needed by the yaml files

Example output:
```
=====================================================================
1st order dynamics
pitch fit percentage: 85.524922%
roll fit percentage: 86.501898%

---------------------------------------------------------------------
Copy the following into your nonlinear_mpc.yaml file
---------------------------------------------------------------------
# Controller Parameters:
mass: 2.500000
roll_time_constant: 0.141111
roll_gain: 1.037908
pitch_time_constant: 0.138129
pitch_gain: 1.035411
linear_drag_coefficients: [0.020000, 0.020000, 0.000000]
yaw_gain: 1.000000
---------------------------------------------------------------------
=====================================================================
2nd order dynamics
pitch fit percentage: 89.155261%
roll fit percentage: 91.344527%

---------------------------------------------------------------------
Copy the following into your disturbance_observer.yaml file
---------------------------------------------------------------------
  #model from system identification (2nd order attitude model)
  drag_coefficients: [0.020000, 0.020000, 0.000000]
  roll_gain: 0.964957
  roll_damping: 0.672272
  roll_omega: 10.540684
  pitch_gain: 0.970397
  pitch_damping: 0.648367
  pitch_omega: 10.177723
  yaw_gain: 1.000000
  yaw_damping: 0.950000
  yaw_omega: 5.000000
---------------------------------------------------------------------
=====================================================================
pixhawk thrust settings
---------------------------------------------------------------------
Copy the following into your px4_config.yaml file
---------------------------------------------------------------------
# setpoint_raw
setpoint_raw:
  thrust_scaling_factor: 0.010384
  system_mass_kg: 2.500000
  yaw_rate_scaling_factor: 1.000000
---------------------------------------------------------------------
```